### PR TITLE
Don't fail on nil input

### DIFF
--- a/lib/vidibus/words.rb
+++ b/lib/vidibus/words.rb
@@ -6,7 +6,7 @@ module Vidibus
     class MissingLocaleError < StandardError; end
 
     def initialize(input, loc = [])
-      @input = input
+      @input = input || ''
       self.locale = loc
     end
 

--- a/lib/vidibus/words.rb
+++ b/lib/vidibus/words.rb
@@ -71,6 +71,7 @@ module Vidibus
 
       # Returns a list of words from given string.
       def words(string)
+        return [] if string.nil?
         allowed = [' ', 'a-z', 'A-Z', '0-9'] + String::LATIN_MAP.values
         disallowed = ['¿', '¡'] # Add some disallowed chars that cannot be catched. TODO: Improve!
         match = /[^#{allowed.join('')}]/

--- a/spec/vidibus/words_spec.rb
+++ b/spec/vidibus/words_spec.rb
@@ -164,6 +164,10 @@ describe 'Vidibus::Words' do
     it 'should remove double non-word chars' do
       Vidibus::Words.words('-¡Defensa india de dama!-').should eql(%w[Defensa india de dama])
     end
+
+    it 'should not fail on nil input string' do
+      Vidibus::Words.words(nil).should eq([])
+    end
   end
 
   describe '.sort_by_occurrence' do

--- a/spec/vidibus/words_spec.rb
+++ b/spec/vidibus/words_spec.rb
@@ -7,7 +7,7 @@ describe 'Vidibus::Words' do
       expect {Vidibus::Words.new}.to raise_error(ArgumentError)
     end
 
-    it 'should accept nil and convert it to an empty array' do
+    it 'should accept nil and convert it to an empty string' do
       words = Vidibus::Words.new(nil)
       words.input.should eq('')
     end

--- a/spec/vidibus/words_spec.rb
+++ b/spec/vidibus/words_spec.rb
@@ -7,6 +7,11 @@ describe 'Vidibus::Words' do
       expect {Vidibus::Words.new}.to raise_error(ArgumentError)
     end
 
+    it 'should accept nil and convert it to an empty array' do
+      words = Vidibus::Words.new(nil)
+      words.input.should eq('')
+    end
+
     it 'should accept an additional argument to set locales' do
       words = Vidibus::Words.new('hello', :en)
       words.locales.should eql([:en])
@@ -79,6 +84,11 @@ describe 'Vidibus::Words' do
 
     it 'should accept an optional length param' do
       words.keywords(30).length.should eql(30)
+    end
+
+    it 'should not fail on nil input string' do
+      words = Vidibus::Words.new(nil)
+      words.keywords.should eq []
     end
   end
 


### PR DESCRIPTION
Make sure that a nil input value for Vidibus::Words.new(nil).keywords and Vidibus::Words.words(nil) does not fail. Instead return an empty array.
